### PR TITLE
Add auto-rebase workflow

### DIFF
--- a/.github/workflows/dotnet-dependencies-updated.yml
+++ b/.github/workflows/dotnet-dependencies-updated.yml
@@ -1,0 +1,14 @@
+name: dotnet-dependencies-updated
+
+on:
+  repository_dispatch:
+    types: [ dotnet_dependencies_updated ]
+
+permissions: {}
+
+jobs:
+  rebase:
+    uses: ./.github/workflows/rebase.yml
+    secrets: inherit
+    with:
+      repository: ${{ github.event.client_payload.repository }}

--- a/.github/workflows/rebase.yml
+++ b/.github/workflows/rebase.yml
@@ -1,6 +1,17 @@
 name: rebase
 
 on:
+  workflow_call:
+    inputs:
+      branch:
+        description: "The branch to rebase."
+        required: false
+        type: string
+        default: "dotnet-vnext"
+      repository:
+        description: "The repository to rebase."
+        required: true
+        type: string
   workflow_dispatch:
     inputs:
       branch:


### PR DESCRIPTION
Add a workflow that runs the rebase workflow for a specific repository if a repository dispatch event is received for `dotnet_dependencies_updated`.

See martincostello/costellobot#695 for how the event is generated.
