### PR TITLE
Use repository as run name

### DIFF
--- a/.github/workflows/dotnet-dependencies-updated.yml
+++ b/.github/workflows/dotnet-dependencies-updated.yml
@@ -1,4 +1,5 @@
 name: dotnet-dependencies-updated
+run-name: ${{ github.event.client_payload.repository }}
 
 on:
   repository_dispatch:


### PR DESCRIPTION
Use the name of the repository that triggered the workflow as the workflow run's name.
