### PR TITLE
Handle multiple PRs for a branch

### DIFF
--- a/.github/workflows/dotnet-upgrade-report.yml
+++ b/.github/workflows/dotnet-upgrade-report.yml
@@ -112,7 +112,7 @@ jobs:
             }
 
             $defaultBranch = gh api "repos/${repo}" --jq '.default_branch'
-            $branchPR = gh api "repos/${repo}/commits/${head}/pulls" --jq ".[] | select(.base.ref == `"${defaultBranch}`") | .number"
+            $branchPR = gh api "repos/${repo}/commits/${head}/pulls" --jq ('.[] | select(.base.ref == "' + ${defaultBranch} + '") | .number')
             $pr = gh api "repos/${repo}/pulls/${branchPR}" --jq '{ number: .number, url: .html_url, mergeable_state: .mergeable_state }' | ConvertFrom-Json
 
             $checkStatuses = `

--- a/.github/workflows/dotnet-upgrade-report.yml
+++ b/.github/workflows/dotnet-upgrade-report.yml
@@ -111,10 +111,8 @@ jobs:
               continue
             }
 
-            $defaultBranch = gh api "repos/${repo}" --jq '.default_branch'
-            $query = ".[] | select(.base.ref == `"${defaultBranch}`") | .number"
-            Write-Output "::debug::${query}"
-            $branchPR = gh api "repos/${repo}/commits/${head}/pulls" --jq $query
+            $env:repo_default_branch = gh api "repos/${repo}" --jq '.default_branch'
+            $branchPR = gh api "repos/${repo}/commits/${head}/pulls" --jq '.[] | select(.base.ref == env.repo_default_branch) | .number'
             $pr = gh api "repos/${repo}/pulls/${branchPR}" --jq '{ number: .number, url: .html_url, mergeable_state: .mergeable_state }' | ConvertFrom-Json
 
             $checkStatuses = `

--- a/.github/workflows/dotnet-upgrade-report.yml
+++ b/.github/workflows/dotnet-upgrade-report.yml
@@ -113,6 +113,7 @@ jobs:
 
             $defaultBranch = gh api "repos/${repo}" --jq '.default_branch'
             $query = ".[] | select(.base.ref == `"${defaultBranch}`") | .number"
+            Write-Output "::debug::${query}"
             $branchPR = gh api "repos/${repo}/commits/${head}/pulls" --jq $query
             $pr = gh api "repos/${repo}/pulls/${branchPR}" --jq '{ number: .number, url: .html_url, mergeable_state: .mergeable_state }' | ConvertFrom-Json
 

--- a/.github/workflows/dotnet-upgrade-report.yml
+++ b/.github/workflows/dotnet-upgrade-report.yml
@@ -111,7 +111,8 @@ jobs:
               continue
             }
 
-            $branchPR = gh api "repos/${repo}/commits/${head}/pulls" --jq '.[0] | .number '
+            $defaultBranch = gh api "repos/${repo}" --jq '.default_branch'
+            $branchPR = gh api "repos/${repo}/commits/${head}/pulls" --jq ".[] | select(.base.ref == `"${defaultBranch}`") | .number"
             $pr = gh api "repos/${repo}/pulls/${branchPR}" --jq '{ number: .number, url: .html_url, mergeable_state: .mergeable_state }' | ConvertFrom-Json
 
             $checkStatuses = `

--- a/.github/workflows/dotnet-upgrade-report.yml
+++ b/.github/workflows/dotnet-upgrade-report.yml
@@ -112,7 +112,8 @@ jobs:
             }
 
             $defaultBranch = gh api "repos/${repo}" --jq '.default_branch'
-            $branchPR = gh api "repos/${repo}/commits/${head}/pulls" --jq ('.[] | select(.base.ref == "' + ${defaultBranch} + '") | .number')
+            $query = ".[] | select(.base.ref == `"${defaultBranch}`") | .number"
+            $branchPR = gh api "repos/${repo}/commits/${head}/pulls" --jq $query
             $pr = gh api "repos/${repo}/pulls/${branchPR}" --jq '{ number: .number, url: .html_url, mergeable_state: .mergeable_state }' | ConvertFrom-Json
 
             $checkStatuses = `

--- a/.github/workflows/rebase.yml
+++ b/.github/workflows/rebase.yml
@@ -158,10 +158,16 @@ jobs:
             if (prs.data.length < 1) {
               return false;
             }
+            const repository = await github.rest.repos.get({
+              owner,
+              repo,
+            });
+            const default_branch = repository.data.default_branch;
+            const pull_number = prs.data.find((pull) => pull.base.ref === default_branch).number;
             const pr = await github.rest.pulls.get({
               owner,
               repo,
-              pull_number: prs.data[0].number,
+              pull_number,
             });
             return pr.data.mergeable_state === 'dirty';
 


### PR DESCRIPTION
In the event that there are more than one PR associated with a commit for the branch, take the one that targets the default branch.
