### PR TITLE
Workflow improvements

### DIFF
--- a/.github/actionlint-matcher.json
+++ b/.github/actionlint-matcher.json
@@ -1,0 +1,17 @@
+{
+  "problemMatcher": [
+    {
+      "owner": "actionlint",
+      "pattern": [
+        {
+          "regexp": "^(?:\\x1b\\[\\d+m)?(.+?)(?:\\x1b\\[\\d+m)*:(?:\\x1b\\[\\d+m)*(\\d+)(?:\\x1b\\[\\d+m)*:(?:\\x1b\\[\\d+m)*(\\d+)(?:\\x1b\\[\\d+m)*: (?:\\x1b\\[\\d+m)*(.+?)(?:\\x1b\\[\\d+m)* \\[(.+?)\\]$",
+          "file": 1,
+          "line": 2,
+          "column": 3,
+          "message": 4,
+          "code": 5
+        }
+      ]
+    }
+  ]
+}

--- a/.github/workflows/dotnet-release.yml
+++ b/.github/workflows/dotnet-release.yml
@@ -43,6 +43,9 @@ jobs:
             const currentSha = branch.data.commit.sha;
             const previousSha = '${{ inputs.ref || vars.DOTNET_CORE_SHA }}';
 
+            console.log(` Current SHA: ${currentSha}`);
+            console.log(`Previous SHA: ${previousSha}`);
+
             let releaseNotesFiles = [];
             let updatedSha = '';
 
@@ -56,6 +59,8 @@ jobs:
               releaseNotesFiles = diff.data.files
                 .map(file => file.filename)
                 .filter(file => file.startsWith('release-notes/') && file.endsWith('/releases.json'));
+
+              console.log(`${releaseNotesFiles} release notes file(s) were updated.`);
             }
 
             const releaseNotesUpdated = releaseNotesFiles.length > 0;
@@ -84,6 +89,8 @@ jobs:
                 const notes = JSON.parse(release);
                 delete notes.releases;
 
+                console.log(`Release notes for ${path}:\n${JSON.stringify(notes, null, 2)}`);
+
                 releaseNotes.push(notes);
               }
             }
@@ -109,22 +116,30 @@ jobs:
       #  with:
       #    github-token: ${{ secrets.ACCESS_TOKEN }}
       #    script: |
+      #      const sha = '${{ needs.check-for-release.outputs.dotnet-core-updated-sha }}';
       #      await github.rest.actions.updateRepoVariable({
       #        owner: context.repo.owner,
       #        repo: context.repo.repo,
       #        name: 'DOTNET_CORE_SHA',
-      #        value: '${{ needs.check-for-release.outputs.dotnet-core-updated-sha }}'
+      #        value: sha,
       #      });
+      #      core.notice(`dotnet/core SHA updated to ${sha}`);
         shell: pwsh
         env:
           GH_TOKEN: ${{ secrets.ACCESS_TOKEN }}
         run: |
+          $sha = "${{ needs.check-for-release.outputs.dotnet-core-updated-sha }}"
           gh api --method PATCH "/repos/${{ github.repository }}/actions/variables/DOTNET_CORE_SHA" -f value='${{ needs.check-for-release.outputs.dotnet-core-updated-sha }}'
+          Write-Output "::notice::dotnet/core SHA updated to ${sha}"
 
   create-dispatch:
     name: create-dispatch
     needs: check-for-release
     if: ${{ needs.check-for-release.outputs.dotnet-releases-updated == 'true' }}
+
+    concurrency:
+      group: "create-dispatch"
+      cancel-in-progress: false
 
     permissions:
       contents: write
@@ -155,13 +170,16 @@ jobs:
               branchesToDispatch.push('dotnet-vnext');
             }
 
+            const event_type = 'dotnet_release';
+
             for (let branch of branchesToDispatch) {
               await github.rest.repos.createDispatchEvent({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                event_type: 'dotnet_release',
+                event_type,
                 client_payload: {
                   branch
                 }
               });
+              core.notice(`Dispatched ${event_type} for branch ${branch}`);
             }

--- a/.github/workflows/dotnet-release.yml
+++ b/.github/workflows/dotnet-release.yml
@@ -148,11 +148,11 @@ jobs:
             };
 
             const branchesToDispatch = [];
-            if (releaseNotes.some(release => isPreview(release))) {
-              branchesToDispatch.push('dotnet-vnext');
-            }
             if (releaseNotes.some(release => !isPreview(release))) {
               branchesToDispatch.push('main');
+            }
+            if (releaseNotes.some(release => isPreview(release))) {
+              branchesToDispatch.push('dotnet-vnext');
             }
 
             for (let branch of branchesToDispatch) {

--- a/.github/workflows/dotnet-upgrade-report.yml
+++ b/.github/workflows/dotnet-upgrade-report.yml
@@ -10,6 +10,9 @@ permissions: {}
 jobs:
   generate:
     runs-on: ubuntu-latest
+    concurrency:
+      group: ${{ github.workflow }}
+      cancel-in-progress: false
     steps:
       - name: Generate report
         shell: pwsh

--- a/.github/workflows/dotnet-version-report.yml
+++ b/.github/workflows/dotnet-version-report.yml
@@ -8,6 +8,9 @@ permissions: {}
 jobs:
   generate:
     runs-on: ubuntu-latest
+    concurrency:
+      group: ${{ github.workflow }}
+      cancel-in-progress: false
     steps:
       - name: Generate report
         shell: pwsh

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,37 @@
+name: lint
+
+on:
+  push:
+    branches: [ main ]
+    paths-ignore:
+    - '**/*.gitattributes'
+    - '**/*.gitignore'
+    - '**/*.md'
+  pull_request:
+    branches: [ main, dotnet-vnext ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  FORCE_COLOR: 3
+  TERM: xterm
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+
+    - name: Checkout code
+      uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+
+    - name: Lint workflows
+      shell: bash
+      env:
+        ACTIONLINT_VERSION: '7b75d16d41920ec126e6f3269db0c6f3ab613c38' # v1.6.25
+      run: |
+        echo "::add-matcher::.github/actionlint-matcher.json"
+        bash <(curl "https://raw.githubusercontent.com/rhysd/actionlint/${ACTIONLINT_VERSION}/scripts/download-actionlint.bash")
+        ./actionlint -color

--- a/.github/workflows/rebase.yml
+++ b/.github/workflows/rebase.yml
@@ -44,7 +44,7 @@ jobs:
   get-repos:
 
     outputs:
-      repos: ${{ steps.get-repos.outputs.repos }}
+      repos: ${{ steps.needs-rebase.outputs.result }}
 
     permissions: {}
 
@@ -95,6 +95,56 @@ jobs:
           $reposJson = ConvertTo-Json $repos -Compress
           "repos=${reposJson}" >> $env:GITHUB_OUTPUT
 
+      - name: Check if branches need rebasing
+        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6.4.1
+        id: needs-rebase
+        with:
+          github-token: ${{ secrets.ACCESS_TOKEN }}
+          result-encoding: string
+          script: |
+            const repos = JSON.parse(`${{ steps.get-repos.outputs.repos }}`);
+            const dirtyRepos = [];
+            for (let i = 0; i < repos.length; i++) {
+              const [ owner, repo ] = repos[i].split('/');
+              let commit_sha;
+              try {
+                const branch = await github.rest.repos.getBranch({
+                  owner,
+                  repo,
+                  branch: '${{ inputs.branch }}',
+                });
+                commit_sha = branch.data.commit.sha;
+              } catch (err) {
+                core.debug(`Could not get branch: ${err}`);
+                return false;
+              }
+              const prs = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+                owner,
+                repo,
+                commit_sha,
+              });
+              if (prs.data.length < 1) {
+                return false;
+              }
+              const repository = await github.rest.repos.get({
+                owner,
+                repo,
+              });
+              const default_branch = repository.data.default_branch;
+              const pull_number = prs.data.find((pull) => pull.base.ref === default_branch).number;
+              const pr = await github.rest.pulls.get({
+                owner,
+                repo,
+                pull_number,
+              });
+              const isDirty = pr.data.mergeable_state === 'dirty';
+              if (isDirty) {
+                core.notice(`${repos[i]} needs rebasing.`);
+                dirtyRepos.push(repos[i]);
+              }
+            }
+            return JSON.stringify(dirtyRepos);
+
   build:
     needs: get-repos
     if: ${{ fromJson(needs.get-repos.outputs.repos).length > 0 }}
@@ -139,50 +189,8 @@ jobs:
         repo: ${{ fromJSON(needs.get-repos.outputs.repos) }}
 
     steps:
-      - name: Check if branch needs rebasing
-        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6.4.1
-        id: needs-rebase
-        with:
-          github-token: ${{ secrets.ACCESS_TOKEN }}
-          result-encoding: string
-          script: |
-            const [ owner, repo ] = '${{ matrix.repo }}'.split('/');
-            let commit_sha;
-            try {
-              const branch = await github.rest.repos.getBranch({
-                owner,
-                repo,
-                branch: '${{ inputs.branch }}',
-              });
-              commit_sha = branch.data.commit.sha;
-            } catch (err) {
-              core.debug(`Could not get branch: ${err}`);
-              return false;
-            }
-            const prs = await github.rest.repos.listPullRequestsAssociatedWithCommit({
-              owner,
-              repo,
-              commit_sha,
-            });
-            if (prs.data.length < 1) {
-              return false;
-            }
-            const repository = await github.rest.repos.get({
-              owner,
-              repo,
-            });
-            const default_branch = repository.data.default_branch;
-            const pull_number = prs.data.find((pull) => pull.base.ref === default_branch).number;
-            const pr = await github.rest.pulls.get({
-              owner,
-              repo,
-              pull_number,
-            });
-            return pr.data.mergeable_state === 'dirty';
-
       - name: Checkout code
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
-        if: ${{ steps.needs-rebase.outputs.result == 'true' }}
         with:
           repository: ${{ matrix.repo }}
           ref: ${{ inputs.branch }}
@@ -191,14 +199,12 @@ jobs:
 
       - name: Download artifacts
         uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
-        if: ${{ steps.needs-rebase.outputs.result == 'true' }}
         with:
           name: rebaser
           path: ./artifacts
 
       - name: Rebase ${{ inputs.branch }}
         shell: pwsh
-        if: ${{ steps.needs-rebase.outputs.result == 'true' }}
         env:
           GH_TOKEN: ${{ secrets.ACCESS_TOKEN }}
         run: |

--- a/.github/workflows/rebase.yml
+++ b/.github/workflows/rebase.yml
@@ -41,35 +41,16 @@ env:
   TERM: xterm
 
 jobs:
-  build:
-    name: build
+  get-repos:
 
     outputs:
       repos: ${{ steps.get-repos.outputs.repos }}
 
-    permissions:
-      contents: read
+    permissions: {}
 
     runs-on: [ ubuntu-latest ]
 
     steps:
-
-      - name: Checkout code
-        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
-
-      - name: Setup .NET SDK
-        uses: actions/setup-dotnet@3447fd6a9f9e57506b15f895c5b76d3b197dc7c2 # v3.2.0
-
-      - name: Build rebaser
-        shell: pwsh
-        run: dotnet publish ./src/Rebaser/Rebaser.csproj --configuration Release --output ./artifacts --runtime linux-x64 --self-contained true
-
-      - name: Publish artifacts
-        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
-        with:
-          name: rebaser
-          path: ./artifacts
-          if-no-files-found: error
 
       - name: Get repositories to rebase
         id: get-repos
@@ -114,9 +95,37 @@ jobs:
           $reposJson = ConvertTo-Json $repos -Compress
           "repos=${reposJson}" >> $env:GITHUB_OUTPUT
 
+  build:
+    needs: get-repos
+    if: ${{ fromJson(needs.get-repos.outputs.repos).length > 0 }}
+
+    permissions:
+      contents: read
+
+    runs-on: [ ubuntu-latest ]
+
+    steps:
+
+      - name: Checkout code
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+
+      - name: Setup .NET SDK
+        uses: actions/setup-dotnet@3447fd6a9f9e57506b15f895c5b76d3b197dc7c2 # v3.2.0
+
+      - name: Build rebaser
+        shell: pwsh
+        run: dotnet publish ./src/Rebaser/Rebaser.csproj --configuration Release --output ./artifacts --runtime linux-x64 --self-contained true
+
+      - name: Publish artifacts
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+        with:
+          name: rebaser
+          path: ./artifacts
+          if-no-files-found: error
+
   rebase:
     name: "rebase-${{ matrix.repo }}"
-    needs: [ build ]
+    needs: [ get-repos, build ]
     runs-on: [ ubuntu-latest ]
 
     concurrency:
@@ -127,7 +136,7 @@ jobs:
       fail-fast: false
       max-parallel: 2
       matrix:
-        repo: ${{ fromJSON(needs.build.outputs.repos) }}
+        repo: ${{ fromJSON(needs.get-repos.outputs.repos) }}
 
     steps:
       - name: Check if branch needs rebasing


### PR DESCRIPTION
- Dispatch main before dotnet-vnext so it takes priority.
- Only allow one report to be generated simultaneously.
- Add logging to the dotnet-release workflow.
- Add concurrency to the `create-dispatch` job.
- Only build rebaser if there are any repositories to rebase.
- Add actionlint to lint the GitHub Actions workflows.
