### PR TITLE
Log mergeable_state

### DIFF
--- a/.github/workflows/rebase.yml
+++ b/.github/workflows/rebase.yml
@@ -172,6 +172,7 @@ jobs:
                 repo,
                 pull_number,
               });
+              core.debug(`${owner}/${repo}#${pull_number} mergeable_state: ${pr.data.mergeable_state}.`);
               const isDirty = pr.data.mergeable_state === 'dirty';
               if (isDirty) {
                 core.notice(`${repos[i]} needs rebasing.`);


### PR DESCRIPTION
Log the value of `mergeable_state` at debug which might help get to the bottom of why conflicts aren't being detected immediately after a merge.
