### PR TITLE
Poll for mergeable state

### DIFF
--- a/.github/workflows/rebase.yml
+++ b/.github/workflows/rebase.yml
@@ -167,12 +167,38 @@ jobs:
                 continue;
               }
               const pull_number = pull_for_ref.number;
-              const pr = await github.rest.pulls.get({
+              let pr = await github.rest.pulls.get({
                 owner,
                 repo,
                 pull_number,
               });
               core.debug(`${owner}/${repo}#${pull_number} mergeable_state: ${pr.data.mergeable_state}.`);
+
+              // Poll for changes for up to 1 minute with a 5 second delay between polls if pr.data.mergeable_state is null.
+              // The first read will start a background job to re-calcuate the mergeability, but it may not be ready immediately.
+              // See https://docs.github.com/en/rest/guides/using-the-rest-api-to-interact-with-your-git-database?apiVersion=2022-11-28#checking-mergeability-of-pull-requests
+              // and https://github.com/pullreminders/backlog/issues/42#issuecomment-436412823.
+              let pollCount = 0;
+              const pollDelay = 5000;
+              const timeout = 60000;
+              const maxPollCount = 60000 / pollDelay;
+              while (pr.data.mergeable_state === null && pollCount < maxPollCount) {
+                await new Promise((resolve) => setTimeout(resolve, pollDelay));
+                pr = await github.rest.pulls.get({
+                  owner,
+                  repo,
+                  pull_number,
+                  // Specify cache headers to make the most of the GitHub API's rate limits.
+                  // See https://jamiemagee.co.uk/blog/making-the-most-of-github-rate-limits/.
+                  headers: {
+                    'If-Modified-Since': pr.headers['Last-Modified'],
+                    'If-None-Match': pr.headers['Etag'],
+                  },
+                });
+                core.debug(`${owner}/${repo}#${pull_number} mergeable_state: ${pr.data.mergeable_state}.`);
+                pollCount++;
+              }
+
               const isDirty = pr.data.mergeable_state === 'dirty';
               if (isDirty) {
                 core.notice(`${repos[i]} needs rebasing.`);


### PR DESCRIPTION
The mergeability of the pull request might not be recalculated straight away. In that case poll for up to a minute until the state is available so that a rebase can be attempted if required.
