### PR TITLE
Bump github/issue-metrics to v2.3.0

### DIFF
--- a/.github/workflows/issue-metrics.yml
+++ b/.github/workflows/issue-metrics.yml
@@ -19,27 +19,13 @@ jobs:
       id: last-month
       shell: bash
       run: |
-        # Get the current date
-        current_date=$(date +'%Y-%m-%d')
-
-        # Calculate the previous month
-        previous_date=$(date -d "$current_date -1 month" +'%Y-%m-%d')
-
-        # Extract the year and month from the previous date
-        previous_year=$(date -d "$previous_date" +'%Y')
-        previous_month=$(date -d "$previous_date" +'%m')
-
-        # Calculate the first day of the previous month
-        first_day=$(date -d "$previous_year-$previous_month-01" +'%Y-%m-%d')
-
-        # Calculate the last day of the previous month
-        last_day=$(date -d "$first_day +1 month -1 day" +'%Y-%m-%d')
-
+        first_day=$(date -d "last month" +%Y-%m-01)
+        last_day=$(date -d "$first_day +1 month -1 day" +%Y-%m-%d)
         echo "$first_day..$last_day"
         echo "last-month=$first_day..$last_day" >> "$GITHUB_OUTPUT"
 
     - name: Run issue-metrics tool
-      uses: github/issue-metrics@88570fc89e9c8861d2b7b9be9f56a5785c282f05 # v2.2.2
+      uses: github/issue-metrics@cf3dda21393dcaf2bbb50f9bac0505f897339122 # v2.3.0
       env:
         GH_TOKEN: ${{ secrets.ACCESS_TOKEN }}
         SEARCH_QUERY: 'owner:${{ github.repository_owner }} is:issue created:${{ steps.last-month.outputs.last-month }} -reason:"not planned"'


### PR DESCRIPTION
- Bump github/issue-metrics to v2.3.0.
- Simplify the date range code.
