### PR TITLE
Move check names to config

### DIFF
--- a/.github/workflow-config.json
+++ b/.github/workflow-config.json
@@ -1,4 +1,16 @@
 {
+  "checksOfInterest": [
+    "code-ql",
+    "code-ql (csharp)",
+    "code-ql (javascript)",
+    "dependency-review",
+    "lighthouse",
+    "lint",
+    "macos-latest",
+    "ubuntu-latest",
+    "validate-packages",
+    "windows-latest"
+  ],
   "repositories": [
     "justeattakeaway/ApplePayJSSample",
     "justeattakeaway/httpclient-interception",

--- a/.github/workflows/dotnet-upgrade-report.yml
+++ b/.github/workflows/dotnet-upgrade-report.yml
@@ -36,19 +36,6 @@ jobs:
               branch = default_branch;
             }
 
-            const checksOfInterest = [
-              'code-ql',
-              'code-ql (csharp)',
-              'code-ql (javascript)',
-              'dependency-review',
-              'lighthouse',
-              'lint',
-              'macos-latest',
-              'ubuntu-latest',
-              'validate-packages',
-              'windows-latest',
-            ];
-
             const getFileContents = async (owner, repo, path, ref) => {
               let contents = await github.rest.repos.getContent({
                 owner,
@@ -73,6 +60,7 @@ jobs:
               '${{ github.sha }}'
             ));
 
+            const checksOfInterest = config.checksOfInterest;
             const repos = config.repositories;
 
             function formatSlug(value) {


### PR DESCRIPTION
Move the check names of interest to the configuration file, rather than hard-coding in the script.
