### PR TITLE
Check branch exists when forcing

### DIFF
--- a/.github/workflows/rebase.yml
+++ b/.github/workflows/rebase.yml
@@ -93,11 +93,9 @@ jobs:
           result-encoding: json
           script: |
             const repos = JSON.parse(`${{ steps.get-repos.outputs.repos }}`);
-            if (${{ inputs.force }}) {
-              return repos;
-            }
             const dirtyRepos = [];
             for (let i = 0; i < repos.length; i++) {
+              console.log(`Fetching data for ${repos[i]}.`);
               const [ owner, repo ] = repos[i].split('/');
               let commit_sha;
               try {
@@ -127,47 +125,53 @@ jobs:
                 });
                 base_ref = repository.default_branch;
               }
-              const pull_for_ref = prs.find((pull) => pull.base.ref === base_ref);
-              if (!pull_for_ref) {
-                core.debug(`No pull request found targeting ${base_ref}.`);
-                continue;
-              }
-              const pull_number = pull_for_ref.number;
-              let pr = await github.rest.pulls.get({
-                owner,
-                repo,
-                pull_number,
-              });
-              core.debug(`${owner}/${repo}#${pull_number} mergeable_state: ${pr.data.mergeable_state}.`);
-
-              // Poll for changes if the mergeable state is not yet known if a push just occurred.
-              // The first read above will start a background job to re-calcuate the mergeability, but it may not be ready immediately.
-              // See https://docs.github.com/en/rest/guides/using-the-rest-api-to-interact-with-your-git-database?apiVersion=2022-11-28#checking-mergeability-of-pull-requests
-              // and https://github.com/pullreminders/backlog/issues/42#issuecomment-436412823.
-              let pollCount = 0;
-              const pollDelay = 5000;
-              const timeout = 60000;
-              const maxPollCount = 60000 / pollDelay;
-              while ((pr.data.mergeable_state === null || pr.data.mergeable_state === 'unknown') && pollCount < maxPollCount) {
-                await new Promise((resolve) => setTimeout(resolve, pollDelay));
-                pr = await github.rest.pulls.get({
+              let rebaseBranch = ${{ inputs.force }};
+              if (!rebaseBranch) {
+                const pull_for_ref = prs.find((pull) => pull.base.ref === base_ref);
+                if (!pull_for_ref) {
+                  core.debug(`No pull request found targeting ${base_ref}.`);
+                  continue;
+                }
+                const pull_number = pull_for_ref.number;
+                let pr = await github.rest.pulls.get({
                   owner,
                   repo,
                   pull_number,
-                  // Specify cache headers to make the most of the GitHub API's rate limits.
-                  // See https://jamiemagee.co.uk/blog/making-the-most-of-github-rate-limits/.
-                  headers: {
-                    'If-Modified-Since': pr.headers['Last-Modified'],
-                    'If-None-Match': pr.headers['Etag'],
-                  },
                 });
                 core.debug(`${owner}/${repo}#${pull_number} mergeable_state: ${pr.data.mergeable_state}.`);
-                pollCount++;
+
+                // Poll for changes if the mergeable state is not yet known if a push just occurred.
+                // The first read above will start a background job to re-calcuate the mergeability, but it may not be ready immediately.
+                // See https://docs.github.com/en/rest/guides/using-the-rest-api-to-interact-with-your-git-database?apiVersion=2022-11-28#checking-mergeability-of-pull-requests
+                // and https://github.com/pullreminders/backlog/issues/42#issuecomment-436412823.
+                let pollCount = 0;
+                const pollDelay = 5000;
+                const timeout = 60000;
+                const maxPollCount = 60000 / pollDelay;
+                while ((pr.data.mergeable_state === null || pr.data.mergeable_state === 'unknown') && pollCount < maxPollCount) {
+                  await new Promise((resolve) => setTimeout(resolve, pollDelay));
+                  pr = await github.rest.pulls.get({
+                    owner,
+                    repo,
+                    pull_number,
+                    // Specify cache headers to make the most of the GitHub API's rate limits.
+                    // See https://jamiemagee.co.uk/blog/making-the-most-of-github-rate-limits/.
+                    headers: {
+                      'If-Modified-Since': pr.headers['Last-Modified'],
+                      'If-None-Match': pr.headers['Etag'],
+                    },
+                  });
+                  core.debug(`${owner}/${repo}#${pull_number} mergeable_state: ${pr.data.mergeable_state}.`);
+                  pollCount++;
+                }
+
+                rebaseBranch = pr.data.mergeable_state === 'dirty';
+                if (rebaseBranch) {
+                  core.notice(`${repos[i]} needs rebasing.`);
+                }
               }
 
-              const isDirty = pr.data.mergeable_state === 'dirty';
-              if (isDirty) {
-                core.notice(`${repos[i]} needs rebasing.`);
+              if (rebaseBranch) {
                 dirtyRepos.push(repos[i]);
               }
             }
@@ -217,7 +221,3 @@ jobs:
           else {
             Write-Output "::error::Could not push changes to the ${{ inputs.branch }} branch of ${{ matrix.repo }}."
           }
-
-      - name: Warn if rebase unsuccessful
-        if : ${{ steps.rebase.outputs.result == 'conflicts' || steps.rebase.outputs.result == 'error' }}
-        run: echo "::warning::Could not resolve conflicts for the ${{ inputs.branch }} branch of ${{ matrix.repo }}."


### PR DESCRIPTION
- Still check the target branch exists when force-rebasing.
- Remove redundant warning.
