### PR TITLE
Disable dotnet-vnext dispatch

### DIFF
--- a/.github/workflows/dotnet-release.yml
+++ b/.github/workflows/dotnet-release.yml
@@ -166,9 +166,11 @@ jobs:
             if (releaseNotes.some(release => !isPreview(release))) {
               branchesToDispatch.push('main');
             }
+            /*
             if (releaseNotes.some(release => isPreview(release))) {
               branchesToDispatch.push('dotnet-vnext');
             }
+            */
 
             const event_type = 'dotnet_release';
 


### PR DESCRIPTION
Disable for now as it just creates merge conflicts when the main changes go in.
