### PR TITLE
Disable schedule

### DIFF
--- a/.github/workflows/update-dotnet-sdks-for-nightly.yml
+++ b/.github/workflows/update-dotnet-sdks-for-nightly.yml
@@ -1,8 +1,8 @@
 name: update-dotnet-sdks-for-nightly
 
 on:
-  schedule:
-    - cron:  '00 10 * * *'
+  #schedule:
+  #  - cron:  '00 10 * * *'
   workflow_dispatch:
 
 permissions: {}


### PR DESCRIPTION
Temporarily disable the trigger until custom repo config for the branches can be applied.
