### PR TITLE
Ensure ref has a value

### DIFF
--- a/.github/workflows/update-dotnet-sdks.yml
+++ b/.github/workflows/update-dotnet-sdks.yml
@@ -144,7 +144,7 @@ jobs:
       - name: Close superseded pull requests
         uses: ./actions/tidy-sdk-pulls
         with:
-          base: ${{ matrix.ref }}
+          base: ${{ matrix.ref || 'main' }}
           github-token: ${{ secrets.COSTELLOBOT_TOKEN }}
           repository: ${{ matrix.repo }}
           user: 'costellobot'


### PR DESCRIPTION
Ensure that `ref` has a value when passed to tidy-sdk-pulls.
