### PR TITLE
Run check-dist on PRs only

### DIFF
--- a/.github/workflows/check-dist-failed.yml
+++ b/.github/workflows/check-dist-failed.yml
@@ -21,6 +21,7 @@ jobs:
     steps:
       - name: Add comment
         uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6.4.1
+        with:
           script: |
             const { owner, repo } = context.repo;
             const { data: prs } = await github.rest.repos.listPullRequestsAssociatedWithCommit({

--- a/.github/workflows/check-dist-failed.yml
+++ b/.github/workflows/check-dist-failed.yml
@@ -21,19 +21,19 @@ jobs:
     steps:
       - name: Add comment
         uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6.4.1
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
+            const { owner, repo } = context.repo;
             const { data: prs } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
+              owner,
+              repo,
               commit_sha: context.payload.workflow_run.head_sha,
             });
             if (prs.length > 0) {
+              const pr = prs[0];
               await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: prs[0].number,
-                body: `Hi @${prs[0].user.login} :wave:\n\nIt looks like this pull request makes changes which require the contents of \`dist\` to be updated, but these files have not been included with your changes.\n\nPlease run \`build.ps1\` and commit the changes made to the \`dist\` directory to your branch and push them to this pull request.`,
+                owner,
+                repo,
+                issue_number: pr.number,
+                body: `Hi @${pr.user.login} :wave:\n\nIt looks like this pull request makes changes which require the contents of \`dist\` to be updated, but these files have not been included with your changes.\n\nPlease run \`build.ps1\` and commit the changes made to the \`dist\` directory to your branch and push them to this pull request.`,
               });
             }

--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -1,12 +1,6 @@
 name: check-dist
 
 on:
-  push:
-    branches: [ main ]
-    paths:
-      - 'package.json'
-      - 'package-lock.json'
-      - 'src/**'
   pull_request:
     branches: [ main ]
     paths:
@@ -20,7 +14,7 @@ permissions:
 
 jobs:
   check-dist:
-    if: ${{ github.actor != 'dependabot[bot]' }}
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
 
     steps:
@@ -64,7 +58,7 @@ jobs:
 
       - name: Upload generated dist
         uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
-        if: ${{ failure() && steps.diff.conclusion == 'failure' }}
+        if: failure() && steps.diff.conclusion == 'failure'
         with:
           name: dist
           path: actions/

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -10,7 +10,7 @@ permissions:
 jobs:
   dependency-review:
     runs-on: ubuntu-latest
-    if: ${{ github.event.repository.fork == false }}
+    if: github.event.repository.fork == false
 
     steps:
 

--- a/.github/workflows/rebase.yml
+++ b/.github/workflows/rebase.yml
@@ -85,7 +85,7 @@ jobs:
   rebase:
     name: "rebase-${{ matrix.repo }}"
     needs: get-repos
-    if: ${{ needs.get-repos.outputs.repos != '[]' }}
+    if: needs.get-repos.outputs.repos != '[]'
     runs-on: [ ubuntu-latest ]
 
     concurrency:

--- a/.github/workflows/update-dotnet-sdks.yml
+++ b/.github/workflows/update-dotnet-sdks.yml
@@ -62,7 +62,7 @@ jobs:
   update-sdk:
     name: 'update-${{ matrix.repo }}'
     needs: [ get-repos ]
-    if: ${{ needs.get-repos.outputs.updates != '[]' }}
+    if: needs.get-repos.outputs.updates != '[]'
     uses: martincostello/update-dotnet-sdk/.github/workflows/update-dotnet-sdk.yml@ef5170e2dbee1235ee754f03a6018794c061c8e5 # v2.5.0
 
     concurrency:
@@ -91,7 +91,7 @@ jobs:
 
   update-sdk-external:
     runs-on: [ ubuntu-latest ]
-    if: ${{ inputs.repository == '' }}
+    if: inputs.repository == ''
 
     concurrency:
       group: '${{ github.workflow }}-external'

--- a/.github/workflows/update-static-assets.yml
+++ b/.github/workflows/update-static-assets.yml
@@ -41,7 +41,7 @@ jobs:
     name: 'update-${{ matrix.repo }}'
     needs: get-repos
     runs-on: ubuntu-latest
-    if: ${{ needs.get-repos.outputs.repos != '[]' }}
+    if: needs.get-repos.outputs.repos != '[]'
 
     concurrency:
       group: 'update-assets-${{ matrix.repo }}'


### PR DESCRIPTION
- Only run `check-dist` on pull requests.
- Simplify some JavaScript.
- Remove some redundant escaping.
