### PR TITLE
Disable nightly branches

### DIFF
--- a/.github/workflows/dotnet-upgrade-report-for-nightly.yml
+++ b/.github/workflows/dotnet-upgrade-report-for-nightly.yml
@@ -1,8 +1,8 @@
 name: dotnet-upgrade-report-for-nightly
 
 on:
-  schedule:
-    - cron: '45 10 * * *'
+  #schedule:
+  #  - cron: '45 10 * * *'
   workflow_dispatch:
 
 permissions: {}

--- a/.github/workflows/update-dotnet-sdks-for-nightly.yml
+++ b/.github/workflows/update-dotnet-sdks-for-nightly.yml
@@ -1,8 +1,8 @@
 name: update-dotnet-sdks-for-nightly
 
 on:
-  schedule:
-    - cron:  '00 10 * * *'
+  #schedule:
+  #  - cron:  '00 10 * * *'
   workflow_dispatch:
 
 permissions: {}


### PR DESCRIPTION
Disable the cron schedules for nightly builds until .NET 9.
