### PR TITLE
Update to Node.js v20

### DIFF
--- a/.github/workflows/update-dotnet-sdks.yml
+++ b/.github/workflows/update-dotnet-sdks.yml
@@ -63,7 +63,7 @@ jobs:
     name: 'update-${{ matrix.repo }}'
     needs: [ get-repos ]
     if: needs.get-repos.outputs.updates != '[]'
-    uses: martincostello/update-dotnet-sdk/.github/workflows/update-dotnet-sdk.yml@test-updated-action
+    uses: martincostello/update-dotnet-sdk/.github/workflows/update-dotnet-sdk.yml@ff9625b0ff17fe1c25dc110b52977bcdf8cb6983 # v3.1.3
 
     concurrency:
       group: 'update-sdk-${{ matrix.repo }}'

--- a/.github/workflows/update-dotnet-sdks.yml
+++ b/.github/workflows/update-dotnet-sdks.yml
@@ -63,7 +63,7 @@ jobs:
     name: 'update-${{ matrix.repo }}'
     needs: [ get-repos ]
     if: needs.get-repos.outputs.updates != '[]'
-    uses: martincostello/update-dotnet-sdk/.github/workflows/update-dotnet-sdk.yml@65c5f402b15326dd12d7b1dac63abdbb53ed695c # v3.1.2
+    uses: martincostello/update-dotnet-sdk/.github/workflows/update-dotnet-sdk.yml@test-updated-action
 
     concurrency:
       group: 'update-sdk-${{ matrix.repo }}'


### PR DESCRIPTION
Consume changes from https://github.com/martincostello/update-dotnet-sdk/pull/726 to fix warnings about use of Node.js v16.
