### PR TITLE
Avoid empty step summary

### DIFF
--- a/.github/workflows/dotnet-bumper.yml
+++ b/.github/workflows/dotnet-bumper.yml
@@ -310,6 +310,7 @@ jobs:
             return body;
 
       - name: Output the report
+        if: steps.create-pr.outputs.result != ''
         shell: bash
         env:
           SUMMARY: ${{ steps.create-pr.outputs.result }}


### PR DESCRIPTION
Don't emit a step summary if nothing was updated.
