### PR TITLE
Improve markdown links

### DIFF
--- a/.github/workflows/dotnet-bumper.yml
+++ b/.github/workflows/dotnet-bumper.yml
@@ -304,7 +304,8 @@ jobs:
                   let location = `\`${relativePath}:${edit.line}\``;
 
                   if (!isDryRun) {
-                    const linkUrl = `${process.env.GITHUB_SERVER_URL}/${theirOwner}/${theirRepo}/tree/${process.env.HEAD_BRANCH}/${relativePath}#L${edit.line}`;
+                    const query = relativePath.endsWith('.md') ? '?plain=1' : '';
+                    const linkUrl = `${process.env.GITHUB_SERVER_URL}/${theirOwner}/${theirRepo}/tree/${process.env.HEAD_BRANCH}/${relativePath}${query}#L${edit.line}`;
                     location = `[${location}](${linkUrl})`;
                   }
 


### PR DESCRIPTION
For markdown files, add query parameter to code file links so they render the code, not the rendered markdown, so that the exact line is shown.
