### PR TITLE
URL-encode relative paths

### DIFF
--- a/.github/workflows/dotnet-bumper.yml
+++ b/.github/workflows/dotnet-bumper.yml
@@ -305,7 +305,7 @@ jobs:
 
                   if (!isDryRun) {
                     const query = relativePath.endsWith('.md') ? '?plain=1' : '';
-                    const linkUrl = `${process.env.GITHUB_SERVER_URL}/${theirOwner}/${theirRepo}/tree/${process.env.HEAD_BRANCH}/${relativePath}${query}#L${edit.line}`;
+                    const linkUrl = `${process.env.GITHUB_SERVER_URL}/${theirOwner}/${theirRepo}/tree/${process.env.HEAD_BRANCH}/${encodeURIComponent(relativePath)}${query}#L${edit.line}`;
                     location = `[${location}](${linkUrl})`;
                   }
 


### PR DESCRIPTION
Ensure that relative paths to files in GitHub are escaped appropriately.
