### PR TITLE
Use tools manifest for versions

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -1,0 +1,18 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "dotnet-outdated-tool": {
+      "version": "4.6.0",
+      "commands": [
+        "dotnet-outdated"
+      ]
+    },
+    "MartinCostello.DotNetBumper": {
+      "version": "0.4.1",
+      "commands": [
+        "dotnet-bumper"
+      ]
+    }
+  }
+}

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,3 +21,11 @@ updates:
   reviewers:
     - "martincostello"
   open-pull-requests-limit: 99
+- package-ecosystem: nuget
+  directory: "/"
+  schedule:
+    interval: "daily"
+    time: "05:30"
+    timezone: Europe/London
+  reviewers:
+    - "martincostello"

--- a/.github/workflows/dotnet-bumper.yml
+++ b/.github/workflows/dotnet-bumper.yml
@@ -88,12 +88,13 @@ jobs:
 
       - name: Install .NET tools
         shell: pwsh
-        env:
-          DOTNET_BUMPER_VERSION: '0.4.1'
-          DOTNET_OUTDATED_VERSION: '4.6.0'
         run: |
-          dotnet tool install --global dotnet-outdated-tool --version "$env:DOTNET_OUTDATED_VERSION"
-          dotnet tool install --global MartinCostello.DotNetBumper --version "$env:DOTNET_BUMPER_VERSION"
+          $content = (gh api "repos/${env:GITHUB_REPOSITORY}/contents/.config/dotnet-tools.json" | ConvertFrom-Json).content
+          $toolsConfig = [Text.Encoding]::Utf8.GetString([Convert]::FromBase64String($content)) | ConvertFrom-Json
+          $dotnetBumperVersion = $toolsConfig.tools.'MartinCostello.DotNetBumper'.version
+          $dotnetOutdatedVersion = $toolsConfig.tools.'dotnet-outdated-tool'.version
+          dotnet tool install --global dotnet-outdated-tool --version $dotnetOutdatedVersion
+          dotnet tool install --global MartinCostello.DotNetBumper --version $dotnetBumperVersion
 
       - name: Checkout code
         uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2

--- a/.github/workflows/dotnet-bumper.yml
+++ b/.github/workflows/dotnet-bumper.yml
@@ -89,7 +89,7 @@ jobs:
       - name: Install .NET tools
         shell: pwsh
         run: |
-          $content = (gh api "repos/${env:GITHUB_REPOSITORY}/contents/.config/dotnet-tools.json" | ConvertFrom-Json).content
+          $content = (gh api "repos/${env:GITHUB_REPOSITORY}/contents/.config/dotnet-tools.json?ref=${env:GITHUB_SHA}" | ConvertFrom-Json).content
           $toolsConfig = [Text.Encoding]::Utf8.GetString([Convert]::FromBase64String($content)) | ConvertFrom-Json
           $dotnetBumperVersion = $toolsConfig.tools.'MartinCostello.DotNetBumper'.version
           $dotnetOutdatedVersion = $toolsConfig.tools.'dotnet-outdated-tool'.version


### PR DESCRIPTION
Use a .NET tools manifest to specify the versions of tools to use and configure dependabot to keep them up-to-date.
