### PR TITLE
Remove NoWarn

### DIFF
--- a/.github/workflows/dotnet-bumper.yml
+++ b/.github/workflows/dotnet-bumper.yml
@@ -118,7 +118,6 @@ jobs:
         id: upgrade-dotnet
         shell: pwsh
         env:
-          NoWarn: 'CA1515' # HACK See https://github.com/dotnet/roslyn-analyzers/issues/7192
           DOTNET_CLI_TELEMETRY_OPTOUT: true
           DOTNET_GENERATE_ASPNET_CERTIFICATE: false
           DOTNET_NOLOGO: true


### PR DESCRIPTION
Should no longer be needed after changes in .NET Bumper v0.5.2.
