### PR TITLE
Handle .NET workloads

### DIFF
--- a/.github/workflows/update-dotnet-sdks.yml
+++ b/.github/workflows/update-dotnet-sdks.yml
@@ -64,7 +64,7 @@ jobs:
     name: 'update-${{ matrix.repo }}'
     needs: [ get-repos ]
     if: needs.get-repos.outputs.updates != '[]'
-    uses: martincostello/update-dotnet-sdk/.github/workflows/update-dotnet-sdk.yml@handle-dotnet-workloads # v3.2.1
+    uses: martincostello/update-dotnet-sdk/.github/workflows/update-dotnet-sdk.yml@caa37bca20d50c57dc0173d77f956751bb1a1d55 # v3.2.1
 
     concurrency:
       group: 'update-sdk-${{ matrix.repo }}'

--- a/.github/workflows/update-dotnet-sdks.yml
+++ b/.github/workflows/update-dotnet-sdks.yml
@@ -64,7 +64,7 @@ jobs:
     name: 'update-${{ matrix.repo }}'
     needs: [ get-repos ]
     if: needs.get-repos.outputs.updates != '[]'
-    uses: martincostello/update-dotnet-sdk/.github/workflows/update-dotnet-sdk.yml@df4209bbf7d0b82dd7d0a684ce1b601950061e3c # v3.2.0
+    uses: martincostello/update-dotnet-sdk/.github/workflows/update-dotnet-sdk.yml@handle-dotnet-workloads # v3.2.1
 
     concurrency:
       group: 'update-sdk-${{ matrix.repo }}'


### PR DESCRIPTION
Consume changes from martincostello/update-dotnet-sdk#837 to restore .NET workloads when necessary before running dotnet outdated.
