### PR TITLE
Add ACR housekeeping job

### DIFF
--- a/.github/workflows/acr-housekeeping.yml
+++ b/.github/workflows/acr-housekeeping.yml
@@ -1,0 +1,33 @@
+name: acr-housekeeping
+
+on:
+  schedule:
+    - cron: '0 1 * * *'
+  workflow_dispatch:
+
+permissions: {}
+
+env:
+  FORCE_COLOR: 3
+  TERM: xterm
+
+jobs:
+  purge:
+    runs-on: ubuntu-latest
+
+    steps:
+
+    - name: Azure log in
+      uses: azure/login@v2
+      with:
+        client-id: ${{ secrets.AZURE_CLIENT_ID }}
+        tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+        subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+    - name: Purge old images
+      shell: pwsh
+      env:
+        CONTAINER_REGISTRY: '${{ github.repository_owner }}.azurecr.io'
+      run: |
+        $purgeCommand = "acr purge --filter '.*:.*' --ago 1d --keep 2 --untagged --dry-run"
+        az acr run --cmd $purgeCommand --registry ${env:CONTAINER_REGISTRY} /dev/null


### PR DESCRIPTION
Add a scheduled daily job (as a dry run for now) to purge old images from ACR.

Based on [these instructions](https://learn.microsoft.com/azure/container-registry/container-registry-auto-purge).