### PR TITLE
ACR housekeeping fixes

### DIFF
--- a/.github/workflows/acr-housekeeping.yml
+++ b/.github/workflows/acr-housekeeping.yml
@@ -32,8 +32,6 @@ jobs:
 
     - name: Purge old images
       shell: pwsh
-      env:
-        CONTAINER_REGISTRY: '${{ github.repository_owner }}.azurecr.io'
       run: |
-        $purgeCommand = "acr purge --filter '.*:.*' --ago 1d --keep 2 --untagged --dry-run"
-        az acr run --cmd $purgeCommand --registry ${env:CONTAINER_REGISTRY} /dev/null
+        $purgeCommand = "acr purge --filter '.*:.*' --ago 0d --keep 2 --untagged --dry-run"
+        az acr run --cmd $purgeCommand --registry ${env:GITHUB_REPOSITORY_OWNER} /dev/null

--- a/.github/workflows/acr-housekeeping.yml
+++ b/.github/workflows/acr-housekeeping.yml
@@ -41,5 +41,5 @@ jobs:
       env:
         REPOSITORY: '${{ github.repository_owner }}/${{ matrix.repository }}'
       run: |
-        $purgeCommand = "acr purge --filter '${env:REPOSITORY}:.*' --ago 0d --keep 2 --untagged --dry-run"
+        $purgeCommand = "acr purge --filter '${env:REPOSITORY}:.*' --ago 1d --keep 2 --untagged"
         az acr run --cmd $purgeCommand --registry ${env:GITHUB_REPOSITORY_OWNER} /dev/null

--- a/.github/workflows/acr-housekeeping.yml
+++ b/.github/workflows/acr-housekeeping.yml
@@ -13,6 +13,7 @@ env:
 
 jobs:
   purge:
+    name: 'purge-${{ matrix.repository }}'
     runs-on: ubuntu-latest
 
     environment:
@@ -20,6 +21,11 @@ jobs:
 
     permissions:
       id-token: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        repository: [ api ]
 
     steps:
 
@@ -32,6 +38,8 @@ jobs:
 
     - name: Purge old images
       shell: pwsh
+      env:
+        REPOSITORY: '${{ github.repository_owner }}/${{ matrix.repository }}'
       run: |
-        $purgeCommand = "acr purge --filter '.*:.*' --ago 0d --untagged --dry-run"
+        $purgeCommand = "acr purge --filter '${env:REPOSITORY}:.*' --ago 0d --keep 2 --untagged --dry-run"
         az acr run --cmd $purgeCommand --registry ${env:GITHUB_REPOSITORY_OWNER} /dev/null

--- a/.github/workflows/acr-housekeeping.yml
+++ b/.github/workflows/acr-housekeeping.yml
@@ -15,6 +15,9 @@ jobs:
   purge:
     runs-on: ubuntu-latest
 
+    environment:
+      name: azure
+
     permissions:
       id-token: write
 

--- a/.github/workflows/acr-housekeeping.yml
+++ b/.github/workflows/acr-housekeeping.yml
@@ -33,5 +33,5 @@ jobs:
     - name: Purge old images
       shell: pwsh
       run: |
-        $purgeCommand = "acr purge --filter '.*:.*' --ago 0d --keep 2 --untagged --dry-run"
+        $purgeCommand = "acr purge --filter '.*:.*' --ago 0d --untagged --dry-run"
         az acr run --cmd $purgeCommand --registry ${env:GITHUB_REPOSITORY_OWNER} /dev/null


### PR DESCRIPTION
- Use an environment to scope OIDC access.
- Use a matrix to scope by repository.
- Remove `--dry-run`
- Fix warning.