### PR TITLE
Restore .NET tools

### DIFF
--- a/.github/workflows/dotnet-bumper.yml
+++ b/.github/workflows/dotnet-bumper.yml
@@ -127,6 +127,12 @@ jobs:
           NUGET_XMLDOC_MODE: skip
           TERM: xterm
         run: |
+          $toolsManifest = (Join-Path "." ".config" "dotnet-tools.json")
+          if (Test-Path $toolsManifest) {
+            Write-Host "Restoring .NET tools..."
+            dotnet tool restore
+          }
+
           $tempFile = [System.IO.Path]::GetTempFileName()
           dotnet bumper . --log-format Json --log-path $tempFile --test --upgrade-type ${env:DOTNET_BUMPER_UPGRADE_TYPE}
           "dotnet-bumper-log=${tempFile}" >> $env:GITHUB_OUTPUT


### PR DESCRIPTION
Restore any .NET tools before running .NET Bumper in case it itself is installed, which breaks things.
