### PR TITLE
Workflow tweaks

### DIFF
--- a/.github/workflows/update-docker-dependencies.yml
+++ b/.github/workflows/update-docker-dependencies.yml
@@ -130,13 +130,23 @@ jobs:
 
         foreach ($dependency in $dependencies) {
           $dependencyName = $dependency.name
-          $tags = regctl tag ls $dependencyName --exclude latest
-          $latestRelease = $tags | Select-Object -Last 1
-          $dependencyVersion = $latestRelease.Trim().TrimStart('v')
+
+          $tags = regctl tag ls $dependencyName
+
+          $versions = $tags | ForEach-Object {
+            $parsed = $null
+            if ([Version]::TryParse($_.Trim().TrimStart('v'), [ref]$parsed)) {
+              $parsed
+            }
+          } | Sort-Object -Descending | ForEach-Object ToString
+
+          $dependencyVersion = $versions | Select-Object -First 1
+
           if ($LASTEXITCODE -ne 0) {
             Write-Error "Failed to get the latest image version for ${dependencyName}."
             exit $LASTEXITCODE
           }
+
           $dependency.version = $dependencyVersion
           $dependency.digest = regctl image digest "${dependencyName}:${dependencyVersion}"
           $dependency.repo = "https://github.com/${dependencyName}"

--- a/.github/workflows/update-docker-dependencies.yml
+++ b/.github/workflows/update-docker-dependencies.yml
@@ -166,9 +166,14 @@ jobs:
             $dependencyVersion = $dependency.version
 
             $escapedName = $dependencyName.Replace("/", "\/")
+            $replacement = "uses: docker://${dependencyName}@${dependencyDigest} # v${dependencyVersion}"
+
+            if ($workflowContent.Contains($replacement)) {
+              continue
+            }
 
             $previous = $workflowContent
-            $workflowContent = $previous -Replace "(?m)uses: docker:\/\/${escapedName}@sha256:[A-Fa-f0-9]{64} # v.+$", "uses: docker://${dependencyName}@${dependencyDigest} # v${dependencyVersion}"
+            $workflowContent = $previous -Replace "(?m)uses: docker:\/\/${escapedName}@sha256:[A-Fa-f0-9]{64} # v.+$", $replacement
 
             if ($previous -ne $workflowContent) {
               $updates += $dependency


### PR DESCRIPTION
- Don't try and update the file if the expected content is already there to avoid opening pull requests that just change line endings.
- Sort the tag versions in descending order, ignoring anything that doesn't parse as a `Version` (like `latest` or any prereleases).
