### PR TITLE
Fix checksums

### DIFF
--- a/.github/workflows/nuget-packages-published.yml
+++ b/.github/workflows/nuget-packages-published.yml
@@ -305,7 +305,7 @@ jobs:
         run: |
           find "${ASSETS_PATH}" -type f -name '*' | while read -r fname; do
             echo "Generating checksum for ${fname}"
-            sha256sum "${fname}" >> "${ASSETS_PATH}/checksums.txt"
+            sha256sum "${fname}" | awk '{print $1 "  " basename($2)}' >> "${ASSETS_PATH}/checksums.txt"
           done
           echo "Verifying checksums"
           sha256sum "${ASSETS_PATH}/checksums.txt" --check || exit 1


### PR DESCRIPTION
Fixes #941

Update the `Generate checksums` step in the `.github/workflows/nuget-packages-published.yml` workflow to include only file names in the `checksums.txt` file.

* Modify the `sha256sum` command to use `awk` and `basename` to extract and include only the file names in the output.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/martincostello/github-automation/pull/942?shareId=23c27463-1e4e-40e6-8f86-abfb1a377f9c).