### PR TITLE
Add dotnet-minimal-api-integration-testing

### DIFF
--- a/.github/workflow-config.json
+++ b/.github/workflow-config.json
@@ -27,6 +27,7 @@
     "martincostello/cdn",
     "martincostello/costellobot",
     "martincostello/dependabot-helper",
+    "martincostello/dotnet-minimal-api-integration-testing",
     "martincostello/openapi-extensions",
     "martincostello/SignInWithAppleSample",
     "martincostello/website"


### PR DESCRIPTION
Add static asset updates for the dotnet-minimal-api-integration-testing repository.
