### PR TITLE
Use test branch for updating .NET SDK

### DIFF
--- a/.github/workflows/update-dotnet-sdks.yml
+++ b/.github/workflows/update-dotnet-sdks.yml
@@ -91,7 +91,7 @@ jobs:
     name: 'update-${{ matrix.repo }}'
     needs: [ get-repos ]
     if: needs.get-repos.outputs.updates != '[]'
-    uses: martincostello/update-dotnet-sdk/.github/workflows/update-dotnet-sdk.yml@444b0c97f151b01c8d0646ffd0187c4787c17aeb # v3.8.0
+    uses: martincostello/update-dotnet-sdk/.github/workflows/update-dotnet-sdk.yml@gh-1311 # v3.8.1
 
     concurrency:
       group: 'update-sdk-${{ matrix.repo }}'


### PR DESCRIPTION
Use branch to test changes for handling for .NET daily builds.
