### PR TITLE
Remove dependabot reviewers

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,8 +6,6 @@ updates:
     interval: daily
     time: "05:30"
     timezone: Europe/London
-  reviewers:
-    - "martincostello"
 - package-ecosystem: "npm"
   directory: "/"
   groups:
@@ -22,8 +20,6 @@ updates:
     interval: "daily"
     time: "05:30"
     timezone: Europe/London
-  reviewers:
-    - "martincostello"
   open-pull-requests-limit: 99
 - package-ecosystem: nuget
   directory: "/"
@@ -31,5 +27,3 @@ updates:
     interval: "daily"
     time: "05:30"
     timezone: Europe/London
-  reviewers:
-    - "martincostello"


### PR DESCRIPTION
Remove dependabot reviewers as the option is deprecated.

<!--

Summarise the changes this Pull Request makes.

Please include a reference to a GitHub issue if appropriate.

-->
