### PR TITLE
Support running on one repository

### DIFF
--- a/.github/workflows/update-static-assets.yml
+++ b/.github/workflows/update-static-assets.yml
@@ -33,11 +33,12 @@ jobs:
           GH_TOKEN: ${{ secrets.COSTELLOBOT_TOKEN }}
           REPOSITORY: ${{ github.event.inputs.repository || '' }}
         run: |
-          if (-Not [string]::IsNullOrEmpty(${env:REPOSITORY})) {
-            if (-Not ${env:REPOSITORY}.Contains('/')) {
-              ${env:REPOSITORY} = "${env:GITHUB_REPOSITORY_OWNER}/${env:REPOSITORY}"
+          $repo = ${env:REPOSITORY}
+          if (-Not [string]::IsNullOrEmpty($repo)) {
+            if (-Not $repo.Contains('/')) {
+              $repo = "${env:GITHUB_REPOSITORY_OWNER}/${repo}"
             }
-            $repos = @(${env:REPOSITORY})
+            $repos = @($repo)
           } else {
             $contents = gh api "repos/${env:GITHUB_REPOSITORY}/contents/.github/workflow-config.json?ref=${env:GITHUB_SHA}" | ConvertFrom-Json
             $repos = ([System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($contents.content)) | ConvertFrom-Json).'update-static-assets'

--- a/.github/workflows/update-static-assets.yml
+++ b/.github/workflows/update-static-assets.yml
@@ -4,6 +4,12 @@ on:
   schedule:
     - cron:  '0 5 * * *'
   workflow_dispatch:
+    inputs:
+      repository:
+        description: 'An optional single repository to update.'
+        required: false
+        type: string
+        default: ''
 
 permissions: {}
 
@@ -25,17 +31,26 @@ jobs:
         shell: pwsh
         env:
           GH_TOKEN: ${{ secrets.COSTELLOBOT_TOKEN }}
+          REPOSITORY: ${{ github.event.inputs.repository || '' }}
         run: |
-          $contents = gh api "repos/${{ github.repository }}/contents/.github/workflow-config.json?ref=${{ github.sha }}" | ConvertFrom-Json
-          $repos = ([System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($contents.content)) | ConvertFrom-Json).'update-static-assets'
+          if (-Not [string]::IsNullOrEmpty(${env:REPOSITORY})) {
+            if (-Not ${env:REPOSITORY}.Contains('/')) {
+              ${env:REPOSITORY} = "${env:GITHUB_REPOSITORY_OWNER}/${env:REPOSITORY}"
+            }
+            $repos = @(${env:REPOSITORY})
+          } else {
+            $contents = gh api "repos/${env:GITHUB_REPOSITORY}/contents/.github/workflow-config.json?ref=${env:GITHUB_SHA}" | ConvertFrom-Json
+            $repos = ([System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($contents.content)) | ConvertFrom-Json).'update-static-assets'
+          }
+
           $filteredRepos = @()
           foreach ($repo in $repos) {
-            if ($repo.StartsWith("${{ github.repository_owner }}/")) {
+            if ($repo.StartsWith("${env:GITHUB_REPOSITORY_OWNER}/")) {
               $filteredRepos += $repo
             }
           }
           $reposJson = ConvertTo-Json $filteredRepos -Compress
-          "repos=${reposJson}" >> $env:GITHUB_OUTPUT
+          "repos=${reposJson}" >> ${env:GITHUB_OUTPUT}
 
   update-static-assets:
     name: 'update-${{ matrix.repo }}'


### PR DESCRIPTION
- Update the `update-static-assets` workflow to support only running against one repository.
- Avoid interpolation from the GitHub context.
