### PR TITLE
Skip check-dist for renovate

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,13 +10,15 @@ on:
 env:
   FORCE_COLOR: 1
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   build:
     name: build
     runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
 
     steps:
 
@@ -24,6 +26,7 @@ jobs:
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:
         filter: 'tree:0'
+        persist-credentials: false
         show-progress: false
 
     - name: Setup Node

--- a/.github/workflows/check-dist-failed.yml
+++ b/.github/workflows/check-dist-failed.yml
@@ -5,8 +5,7 @@ on:
     workflows: [ check-dist ]
     types: [ completed ]
 
-permissions:
-  pull-requests: read
+permissions: {}
 
 jobs:
   comment:

--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -9,13 +9,15 @@ on:
       - 'src/**'
   workflow_dispatch:
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   check-dist:
-    if: github.actor != 'dependabot[bot]'
+    if: github.actor != 'dependabot[bot]' && github.actor != 'renovate[bot]'
     runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
 
     steps:
 
@@ -23,6 +25,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           filter: 'tree:0'
+          persist-credentials: false
           show-progress: false
 
       - name: Setup Node

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -30,6 +30,7 @@ jobs:
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:
         filter: 'tree:0'
+        persist-credentials: false
         show-progress: false
 
     - name: Initialize CodeQL

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -4,13 +4,15 @@ on:
   pull_request:
     branches: [ main ]
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   dependency-review:
     runs-on: ubuntu-latest
     if: github.event.repository.fork == false
+
+    permissions:
+      contents: read
 
     steps:
 
@@ -18,6 +20,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           filter: 'tree:0'
+          persist-credentials: false
           show-progress: false
 
       - name: Review dependencies

--- a/.github/workflows/dotnet-bumper.yml
+++ b/.github/workflows/dotnet-bumper.yml
@@ -52,6 +52,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           filter: 'tree:0'
+          persist-credentials: false
           show-progress: false
 
       - name: Get repositories to upgrade

--- a/.github/workflows/dotnet-release.yml
+++ b/.github/workflows/dotnet-release.yml
@@ -28,6 +28,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           filter: 'tree:0'
+          persist-credentials: false
           show-progress: false
 
       - name: Check for new .NET releases

--- a/.github/workflows/dotnet-upgrade-report.yml
+++ b/.github/workflows/dotnet-upgrade-report.yml
@@ -46,6 +46,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           filter: 'tree:0'
+          persist-credentials: false
           show-progress: false
 
       - name: Generate report

--- a/.github/workflows/dotnet-version-report.yml
+++ b/.github/workflows/dotnet-version-report.yml
@@ -19,6 +19,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           filter: 'tree:0'
+          persist-credentials: false
           show-progress: false
 
       - name: Generate report

--- a/.github/workflows/is-dotnet-change-available.yml
+++ b/.github/workflows/is-dotnet-change-available.yml
@@ -19,15 +19,18 @@ on:
         required: true
         type: number
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   check:
     runs-on: ubuntu-latest
+
     concurrency:
       group: '${{ github.workflow }}-${{ inputs.repository }}-${{ inputs.pull }}'
       cancel-in-progress: false
+
+    permissions:
+      contents: read
 
     steps:
 
@@ -35,6 +38,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           filter: 'tree:0'
+          persist-credentials: false
           show-progress: false
 
       - name: Generate report

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,8 +11,7 @@ on:
     branches: [ main ]
   workflow_dispatch:
 
-permissions:
-  contents: read
+permissions: {}
 
 env:
   FORCE_COLOR: 3
@@ -26,12 +25,16 @@ jobs:
   lint:
     runs-on: ubuntu-latest
 
+    permissions:
+      contents: read
+
     steps:
 
     - name: Checkout code
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:
         filter: 'tree:0'
+        persist-credentials: false
         show-progress: false
 
     - name: Add actionlint problem matcher

--- a/.github/workflows/nuget-packages-published.yml
+++ b/.github/workflows/nuget-packages-published.yml
@@ -41,6 +41,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           filter: 'tree:0'
+          persist-credentials: false
           show-progress: false
 
       - name: Setup .NET SDK

--- a/.github/workflows/rebase.yml
+++ b/.github/workflows/rebase.yml
@@ -73,6 +73,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           filter: 'tree:0'
+          persist-credentials: false
           show-progress: false
 
       - name: Get repositories to rebase

--- a/.github/workflows/update-dotnet-sdks.yml
+++ b/.github/workflows/update-dotnet-sdks.yml
@@ -51,6 +51,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           filter: 'tree:0'
+          persist-credentials: false
           show-progress: false
 
       - name: Get repositories to update


### PR DESCRIPTION
- Do not run check-dist for Renovate PRs.
- Do not persist Git credentials.
- Update workflow permissions.
