### PR TITLE
Increase NuGet package timeout

### DIFF
--- a/.github/workflows/update-dotnet-sdks.yml
+++ b/.github/workflows/update-dotnet-sdks.yml
@@ -78,7 +78,7 @@ jobs:
         shell: pwsh
         env:
           PACKAGES: ${{ github.event.client_payload.packages }}
-          PUBLISH_TIMEOUT: '00:45:00'
+          PUBLISH_TIMEOUT: '01:30:00'
         run: |
           $packages = ${env:PACKAGES} -Split ','
 


### PR DESCRIPTION
Wait for 90 minutes, not 45.
