### PR TITLE
Fix GPG signing

### DIFF
--- a/.github/workflows/nuget-packages-published.yml
+++ b/.github/workflows/nuget-packages-published.yml
@@ -315,11 +315,12 @@ jobs:
         if: steps.find-assets.outputs.assets-to-sign == 'true'
         env:
           ASSETS_PATH: ${{ steps.find-assets.outputs.result }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
           GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
         shell: bash
         run: |
-          curl -s "${GITHUB_API_URL}/users/${GITHUB_REPOSITORY_OWNER}/gpg_keys" | jq -r '.[].raw_key' | gpg --import
+          gh api "/users/${GITHUB_REPOSITORY_OWNER}/gpg_keys" --jq ".[].raw_key" | gpg --import
           gpg --list-keys --with-colons | awk -F: '/^fpr:/ { print $10 }' | while read -r key; do
             echo "${key}:6:" | gpg --import-ownertrust
           done


### PR DESCRIPTION
Avoid error when GPG signing and simplify by using `gh`.
