### PR TITLE
Avoid 404 warning

### DIFF
--- a/.github/workflows/trigger-npm-audit-fix.yml
+++ b/.github/workflows/trigger-npm-audit-fix.yml
@@ -35,11 +35,15 @@ jobs:
               const workflow_id = 'npm-audit-fix.yml';
 
               try {
-                await github.rest.repos.getContent({
-                  owner,
-                  repo,
-                  path: `.github/workflows/${workflow_id}`,
-                });
+                try {
+                  await github.rest.repos.getContent({
+                    owner,
+                    repo,
+                    path: `.github/workflows/${workflow_id}`,
+                  });
+                } catch {
+                  continue;
+                }
 
                 try {
                   await github.rest.repos.checkCollaborator({


### PR DESCRIPTION
Avoid logging a 404 warning when the workflow does not exist in the target repository.
