### PR TITLE
Remove dependabot-helper

### DIFF
--- a/.github/workflows/acr-housekeeping.yml
+++ b/.github/workflows/acr-housekeeping.yml
@@ -32,7 +32,6 @@ jobs:
           - api
           - applepayjssample
           - costellobot
-          - dependabot-helper
           - home
           - signinwithapplesample
           - website


### PR DESCRIPTION
Remove from housekeeping as the repository has been archived.
