### PR TITLE
Add integration-tests to retries

### DIFF
--- a/.github/workflow-config.json
+++ b/.github/workflow-config.json
@@ -9,6 +9,7 @@
     "code-ql (csharp)",
     "code-ql (javascript)",
     "dependency-review",
+    "integration-tests",
     "lint",
     "linux",
     "macos",


### PR DESCRIPTION
Automatically retry the `integration-tests` job if it fails.
