### PR TITLE
Fix workflow closure

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -218,7 +218,8 @@ jobs:
               state: 'open',
             });
 
-            const milestone = milestones.find((p) => p.title === process.env.RELEASE_VERSION);
+            const title = process.env.RELEASE_VERSION.split('/').pop();
+            const milestone = milestones.find((p) => p.title === title);
 
             if (!milestone) {
               return;


### PR DESCRIPTION
Split off the version from the tag so the milestone query finds the milestone.
