### PR TITLE
Fix workflows

### DIFF
--- a/.github/workflows/dotnet-bumper.yml
+++ b/.github/workflows/dotnet-bumper.yml
@@ -132,7 +132,7 @@ jobs:
 
       - name: Get GitHub read token
         id: get-github-read-token
-        uses: martincostello/github-automation/actions/get-github-token@567bf2ea7958064af7863e6004a545a799f57982 # get-github-token/v4.2.0
+        uses: martincostello/github-automation/actions/get-github-token@36f156b090e9259937ebf5151c165ddb1fcf6eac # get-github-token/v4.3.0
         with:
           profile-name: dotnet-bumper-read
 
@@ -200,7 +200,7 @@ jobs:
       - name: Get GitHub write token
         id: get-github-write-token
         if: steps.check-for-changes.outputs.has-changes == 'true' && inputs.dry-run != 'true'
-        uses: martincostello/github-automation/actions/get-github-token@567bf2ea7958064af7863e6004a545a799f57982 # get-github-token/v4.2.0
+        uses: martincostello/github-automation/actions/get-github-token@36f156b090e9259937ebf5151c165ddb1fcf6eac # get-github-token/v4.3.0
         with:
           profile-name: dotnet-bumper-write
 

--- a/.github/workflows/issue-metrics.yml
+++ b/.github/workflows/issue-metrics.yml
@@ -37,7 +37,7 @@ jobs:
 
     - name: Get GitHub token
       id: get-github-token
-      uses: ./actions/get-github-token
+      uses: martincostello/github-automation/actions/get-github-token@36f156b090e9259937ebf5151c165ddb1fcf6eac # get-github-token/v4.3.0
       with:
         profile-name: read
 

--- a/.github/workflows/nuget-packages-published.yml
+++ b/.github/workflows/nuget-packages-published.yml
@@ -98,7 +98,7 @@ jobs:
 
       - name: Get GitHub token
         id: get-github-token
-        uses: ./actions/get-github-token
+        uses: martincostello/github-automation/actions/get-github-token@36f156b090e9259937ebf5151c165ddb1fcf6eac # get-github-token/v4.3.0
         with:
           profile-name: comment
 

--- a/.github/workflows/rebase.yml
+++ b/.github/workflows/rebase.yml
@@ -127,7 +127,7 @@ jobs:
 
       - name: Get GitHub token
         id: get-github-token
-        uses: ./actions/get-github-token
+        uses: martincostello/github-automation/actions/get-github-token@36f156b090e9259937ebf5151c165ddb1fcf6eac # get-github-token/v4.3.0
         with:
           profile-name: rebase
 

--- a/.github/workflows/trigger-npm-audit-fix.yml
+++ b/.github/workflows/trigger-npm-audit-fix.yml
@@ -21,7 +21,7 @@ jobs:
 
       - name: Get GitHub token
         id: get-github-token
-        uses: ./actions/get-github-token
+        uses: martincostello/github-automation/actions/get-github-token@36f156b090e9259937ebf5151c165ddb1fcf6eac # get-github-token/v4.3.0
         with:
           profile-name: admin
 

--- a/.github/workflows/update-dotnet-sdks.yml
+++ b/.github/workflows/update-dotnet-sdks.yml
@@ -156,7 +156,7 @@ jobs:
 
       - name: Get GitHub token
         id: get-github-token
-        uses: ./actions/get-github-token
+        uses: martincostello/github-automation/actions/get-github-token@36f156b090e9259937ebf5151c165ddb1fcf6eac # get-github-token/v4.3.0
         with:
           profile-name: external
 

--- a/.github/workflows/update-static-assets.yml
+++ b/.github/workflows/update-static-assets.yml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Get GitHub token
         id: get-github-token
-        uses: ./actions/get-github-token
+        uses: martincostello/github-automation/actions/get-github-token@36f156b090e9259937ebf5151c165ddb1fcf6eac # get-github-token/v4.3.0
         with:
           profile-name: maintenance
 
@@ -96,7 +96,7 @@ jobs:
 
     - name: Get GitHub token
       id: get-github-token
-      uses: ./actions/get-github-token
+      uses: martincostello/github-automation/actions/get-github-token@36f156b090e9259937ebf5151c165ddb1fcf6eac # get-github-token/v4.3.0
       with:
         profile-name: maintenance
 


### PR DESCRIPTION
- Use get-github-token from tag rather than source in workflows that do not check out the repository.
- Update get-github-token to 4.3.0.
