### PR TITLE
Bump martincostello/update-dotnet-sdk

### DIFF
--- a/.github/workflows/update-dotnet-sdks.yml
+++ b/.github/workflows/update-dotnet-sdks.yml
@@ -107,7 +107,7 @@ jobs:
     name: 'update-${{ matrix.repo }}'
     needs: [ get-repos ]
     if: needs.get-repos.outputs.updates != '[]'
-    uses: martincostello/update-dotnet-sdk/.github/workflows/update-dotnet-sdk.yml@fb6d4182e67895769ed694cbefe95df25fa58cd7 # v5.0.4
+    uses: martincostello/update-dotnet-sdk/.github/workflows/update-dotnet-sdk.yml@b7c93e525dbe5e9a7ff3852916c04e5b02ccf44a # v6.0.0
 
     concurrency:
       group: 'update-sdk-${{ matrix.repo }}'


### PR DESCRIPTION
Update martincostello/update-dotnet-sdk to 6.0.0 to test changes from https://github.com/martincostello/update-dotnet-sdk/pull/1923.
