### PR TITLE
Bump martincostello/update-static-assets

### DIFF
--- a/.github/workflows/update-static-assets.yml
+++ b/.github/workflows/update-static-assets.yml
@@ -111,7 +111,7 @@ jobs:
         token: ${{ steps.get-github-token.outputs.token }}
 
     - name: Update static assets
-      uses: martincostello/update-static-assets@0cf1bdb3e08a14b765fa2c8ba87f01b95c7fab07 # v3.0.0
+      uses: martincostello/update-static-assets@97d81a065aa26730f7230fa7ef4e012a2672c53e # v4.0.0
       with:
         file-extensions: 'cshtml,erb,html,razor'
         labels: dependencies


### PR DESCRIPTION
Bump martincostello/update-static-assets to v4.0.0 to consume changes from https://github.com/martincostello/update-static-assets/pull/1565.
